### PR TITLE
Windows: Work around path returned by QUrl

### DIFF
--- a/src/fileaccess.cpp
+++ b/src/fileaccess.cpp
@@ -116,7 +116,21 @@ void FileAccess::setFile(const QUrl& url, bool bWantToWrite)
 
     if(m_url.isLocalFile() || !m_url.isValid() ) // Treat invalid urls as local files.
     {
+#if defined(Q_OS_WIN)
+        // Workaround: The filePath in the QUrl can become of the from "/C:/some/path/file.ext"
+        // when it goes through QUrl::fromUserInput("C:/some/path/file.ext");
+        QString ufp = m_url.path();
+        QString ufpAbs = ufp;
+        if (ufp.length() >= 4 && ufp.at(0) == QLatin1Char('/') &&
+            ufp.at(1).isLetter() && ufp.at(2) == QLatin1Char(':') && ufp.at(3) == QLatin1Char('/'))
+        {
+            ufpAbs = ufp.mid(1); // Drop the first '/'
+        }
+
+        m_fileInfo = QFileInfo(ufpAbs);
+#else
         m_fileInfo = QFileInfo(m_url.path());
+#endif
         m_pParent = nullptr;
 
         loadData();


### PR DESCRIPTION
Built with: `craft kdiff3`
With `ABI = windows-msvc2017_64-cl`
On Windows:
The leading "/" in the path via `QUrl::fromLocalFile` causes some
issues.
`QFileSystemEntry::isAbsolute` "correctly" returns false for paths of the form "/C:/some/path/file.ext"
And hence, `QFileSystemEngine::nativeAbsoluteFilePath` returns an additional `{drive-letter}:\` pre-pended ("C:\\C:\\some\\path\\file.ext")
Callstack:
```QFileSystemEngine::nativeAbsoluteFilePath
QFileSystemEngine::absoluteName
QFileInfoPrivate::getFileName
QFileInfo::absoluteFilePath
FileAccess::loadData```
