### PR TITLE
Revert "Don't run SourceData::readAndPreprocess if m_fileAccess is invalid"

### DIFF
--- a/src/SourceData.cpp
+++ b/src/SourceData.cpp
@@ -343,10 +343,7 @@ const QStringList& SourceData::readAndPreprocess(QTextCodec* pEncoding, bool bAu
     QString fileNameIn2;
     QString fileNameOut2;
 
-    if(!m_fileAccess.isValid())
-        return mErrors;
-
-    if(!m_fileAccess.isNormal())
+    if(m_fileAccess.isValid() && !m_fileAccess.isNormal())
     {
         mErrors.append(i18n("%1 is not a normal file.", m_fileAccess.prettyAbsPath()));
         return mErrors;


### PR DESCRIPTION
This reverts commit 174d2872d08878e806c4200cfc51643cee9bd177.

Fixes a bug that makes it impossible to load contents from clipboard.

https://bugs.kde.org/show_bug.cgi?id=426823